### PR TITLE
Fix import statement for MutableSequence

### DIFF
--- a/life_line_chart/SimpleSVGItems.py
+++ b/life_line_chart/SimpleSVGItems.py
@@ -1,4 +1,8 @@
-from collections import MutableSequence
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    # Required for python versions < 3.9
+    from collections import MutableSequence
 
 
 class Line(object):


### PR DESCRIPTION
MutableSequence is now in collections.abc for python versions >= 3.9